### PR TITLE
Update app.py to load config outside of __main__

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1,7 +1,7 @@
 from flask import (Flask, render_template, request, redirect, url_for, make_response, flash)
 
 app = Flask(__name__)
-
+app.config.from_object('config')
 
 @app.route('/', methods=['GET'])
 def index():
@@ -21,7 +21,6 @@ def reports(task_id=1):
 
 
 if __name__ == "__main__":
-    app.config.from_object('config')
     app.run(debug=app.config['DEBUG'],
             port=app.config['PORT'],
             host=app.config['HOST'])


### PR DESCRIPTION
When hosting the app in Apache using mod_wsgi, it's run by importing the app like so: 'from web.app import app as application'. The code within the 'if name == "__main__"' does not execute in this case, so the config does not get loaded.